### PR TITLE
Update c4ml website url

### DIFF
--- a/program.md
+++ b/program.md
@@ -11,8 +11,8 @@ title: Program
 | Saturday       | AM              | [GRAAL](https://graalworkshop.github.io/2020/)   | [IMOP (half-day)](http://www.cse.iitm.ac.in/~amannoug/imop/tutorials.php)                |
 |                | PM              | [GRAAL](https://graalworkshop.github.io/2020/)   | Women in Compilers (half-day)  |
 | **Conference** |                 | **CGO**     | **CGO**                |
-| Sunday         | AM              | [C4ML](https://c4ml.org/)    | LLVM Performance               |
-|                | PM              | [C4ML](https://c4ml.org/)    | LLVM Performance               |
+| Sunday         | AM              | [C4ML](https://www.c4ml.org/)    | LLVM Performance               |
+|                | PM              | [C4ML](https://www.c4ml.org/)    | LLVM Performance               |
 {:.table-striped}
 
 


### PR DESCRIPTION
For unknown reasons the https entry is returning an error, while if one goes to the http variant it works and ends up at this up at this updated https one. I've not dug into this at all, but updating so that link works.